### PR TITLE
Add github action to update gardenctl

### DIFF
--- a/.github/workflows/update-gardenctl.sh
+++ b/.github/workflows/update-gardenctl.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+filteredTag=${1##*/}
+tag=${filteredTag:-v0.17.0}
+sha=${2:-8d33c751e8d32fe7fff15306c7de59cf15c45fb04e2f9abf988d3edd3f305cc4}
+
+echo $tag
+
+cat > gardenctl.rb << EOF
+class Gardenctl < Formula
+  desc "Gardenctl"
+  homepage "https://gardener.cloud"
+  version "v0.17.0"
+
+  if OS.mac?
+    url "https://github.com/gardener/gardenctl/releases/download/$tag/gardenctl-darwin-amd64"
+    sha256 "$sha"
+  elsif OS.linux?
+    url "https://github.com/gardener/gardenctl/releases/download/$tag/gardenctl-linux-amd64"
+    sha256 "$sha"
+  end
+
+  depends_on :arch => :x86_64
+
+  def install
+    bin.install stable.url.split("/")[-1] => "gardenctl"
+  end
+
+  test do
+    system "#{bin}/gardenctl", "version"
+  end
+end
+
+EOF

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,0 +1,25 @@
+name: Remote Dispatch Action
+on: [repository_dispatch]
+jobs:
+  update-gardenctl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Event Information
+        run: |
+          echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
+          echo  "commit hash '${{ github.event.client_payload.sha }}'"
+      - uses: actions/checkout@v2.1.1
+        # with:
+        #   persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        #   fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Run update script
+        run:  ./.github/workflows/update-gardenctl.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.sha }}
+      - name: Commit files
+        run: |
+          git config --local user.email "gardener.ci.user2@gmail.com"
+          git config --local user.name "gardener-ci2"
+          git commit -m "Update gardenctl" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a github action receiver to update homebrew-tap files. 

related to https://github.com/gardener/gardenctl/pull/202 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update of gardenctl is now automated.
```
