### PR TITLE
remove testing info

### DIFF
--- a/gardenctl.rb
+++ b/gardenctl.rb
@@ -1,14 +1,14 @@
 class Gardenctl < Formula
   desc "Gardenctl"
   homepage "https://gardener.cloud"
-  version "v0.17.0"
+  version "v0.21.0"
 
   if OS.mac?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.25.0/gardenctl-darwin-amd64"
-    sha256 "9a179a17b17bce2094e115b685cfe6fdbce112ed"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.21.0/gardenctl-darwin-amd64"
+    sha256 "7b27b54cb14420bc44fe02c08f1b451f10fb4cd8dd266b414e80c8d9b5f5b286"
   elsif OS.linux?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.25.0/gardenctl-linux-amd64"
-    sha256 "9a179a17b17bce2094e115b685cfe6fdbce112ed"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.21.0/gardenctl-linux-amd64"
+    sha256 "32ceb64608523dc166ce9aa0d89c1c4ee299920cf99e0bfe4953a7c12594e524"
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
**What this PR does / why we need it**:
On Tuesday night @AndreasBurger @zanetworker @dansible @neo-liang-sap did some testing on integration of gardenctl and homebrew-tap, and the testing is causing end user unable to install , hence remove the testing info.
FYI i also removed the testing release `v0.25.0` from gardenctl
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/homebrew-tap/issues/11

**Special notes for your reviewer**:

**Release note**:

```improvement operator

```
