### PR TITLE
upgrade gardenctl version v0.23.0

### DIFF
--- a/gardenctl.rb
+++ b/gardenctl.rb
@@ -1,14 +1,14 @@
 class Gardenctl < Formula
   desc "Gardenctl"
   homepage "https://gardener.cloud"
-  version "v0.21.0"
+  version "v0.22.0"
 
   if OS.mac?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.21.0/gardenctl-darwin-amd64"
-    sha256 "7b27b54cb14420bc44fe02c08f1b451f10fb4cd8dd266b414e80c8d9b5f5b286"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.22.0/gardenctl-darwin-amd64"
+    sha256 "d761188b6cc4be328f070d765cc8b37c49e01c3b45fa98fbb6b4835c2e36d5f2"
   elsif OS.linux?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.21.0/gardenctl-linux-amd64"
-    sha256 "32ceb64608523dc166ce9aa0d89c1c4ee299920cf99e0bfe4953a7c12594e524"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.22.0/gardenctl-linux-amd64"
+    sha256 "afcf3b5c6cf89b74ea936d5888d3be11dbba6c738c52b06433a3ee8f1aa6cd70"
   end
 
   depends_on :arch => :x86_64

--- a/gardenctl.rb
+++ b/gardenctl.rb
@@ -1,14 +1,14 @@
 class Gardenctl < Formula
   desc "Gardenctl"
   homepage "https://gardener.cloud"
-  version "v0.22.0"
+  version "v0.23.0"
 
   if OS.mac?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.22.0/gardenctl-darwin-amd64"
-    sha256 "d761188b6cc4be328f070d765cc8b37c49e01c3b45fa98fbb6b4835c2e36d5f2"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.23.0/gardenctl-darwin-amd64"
+    sha256 "4dfb90eba3d39e6b2d43a1b837e438aaabc2c6a9f7d27de72f5b62258007219c"
   elsif OS.linux?
-    url "https://github.com/gardener/gardenctl/releases/download/v0.22.0/gardenctl-linux-amd64"
-    sha256 "afcf3b5c6cf89b74ea936d5888d3be11dbba6c738c52b06433a3ee8f1aa6cd70"
+    url "https://github.com/gardener/gardenctl/releases/download/v0.23.0/gardenctl-linux-amd64"
+    sha256 "e033065a4e54830004c9c0d6bc1f7d063aa1baa78eae2ddbb7a13600219e811e"
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade gardenctl version v0.22.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
upgrade gardenctl version v0.23.0
```
