### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -10,7 +10,7 @@ jobs:
           echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
           echo "Mac gardenctl binary hash '${{ github.event.client_payload.mac_sha }}'"
           echo "Linux gardenctl binary hash '${{ github.event.client_payload.linux_sha }}'"
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # pin@v2.1.1
       - name: Run update script
         run:  ./.github/workflows/update-gardenctl.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.mac_sha }} ${{ github.event.client_payload.linux_sha }}
       - name: Commit files
@@ -19,7 +19,7 @@ jobs:
           git config --local user.name "gardener-robot-ci-1"
           git commit -m "Update gardenctl" -a
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # pin@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: false
@@ -32,7 +32,7 @@ jobs:
           echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
           echo "Mac gardenlogin binary hash '${{ github.event.client_payload.darwin_sha }}'"
           echo "Linux gardenlogin binary hash '${{ github.event.client_payload.linux_sha }}'"
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # pin@v2.1.1
       - name: Run update script
         run:  ./.github/workflows/update-gardenlogin.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.darwin_sha }} ${{ github.event.client_payload.linux_sha }}
       - name: Commit files
@@ -42,7 +42,7 @@ jobs:
           git add gardenlogin.rb
           git commit -m "Update gardenlogin"
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # pin@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: false


### PR DESCRIPTION
**What this PR does / why we need it**:
https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions

> **Pin actions to a full length commit SHA**
> 
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
