### PR TITLE
Update update-gardenctl-v2.sh: Renamed executable to gardenctl

### DIFF
--- a/.github/workflows/update-gardenctl-v2.sh
+++ b/.github/workflows/update-gardenctl-v2.sh
@@ -52,11 +52,11 @@ class GardenctlV2 < Formula
   depends_on :arch => :x86_64
 
   def install
-    bin.install stable.url.split("/")[-1] => "gardenctl-v2"
+    bin.install stable.url.split("/")[-1] => "gardenctl"
   end
 
   test do
-    system "#{bin}/gardenctl-v2", "version"
+    system "#{bin}/gardenctl", "version"
   end
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We agreed to have separate installation scripts for gardenctl-v1 and gardenctl-v2. So the user can have both installed or roll back.
However, as v2 is meant as a replacement, it's executable should be named gardenctl (without -v2). If one tries to install both versions via brew, a link error will occur that has to be resolved, however this is expected behavior and we will document it in the installation documentation. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
