### PR TITLE
Add gardenctl v1 deprecation warning

### DIFF
--- a/gardenctl.rb
+++ b/gardenctl.rb
@@ -15,6 +15,9 @@ class Gardenctl < Formula
 
   def install
     bin.install stable.url.split("/")[-1] => "gardenctl"
+
+    print "\n[WARNING]\n"
+    print "  gardenctl is deprecated. Please install gardenctl-v2 instead.\n\n"
   end
 
   test do


### PR DESCRIPTION
**What this PR does / why we need it**:
Add gardenctl v1 deprecation warning

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
