### PR TITLE
Support linux/arm64 builds for gardenctl-v2 and gardenlogin

### DIFF
--- a/.github/workflows/update-gardenctl-v2.sh
+++ b/.github/workflows/update-gardenctl-v2.sh
@@ -4,6 +4,7 @@ tag=${1}
 darwin_sha_amd64=${2}
 darwin_sha_arm64=${3}
 linux_sha_amd64=${4}
+linux_sha_arm64=${5}
 if [ -z "${1}" ]
 then
       echo "release tag is not provided"
@@ -21,7 +22,12 @@ then
 fi
 if [ -z "${4}" ]
 then
-      echo "linux binary sha256sum is not provided"
+      echo "linux amd64 binary sha256sum is not provided"
+      exit 1
+fi
+if [ -z "${5}" ]
+then
+      echo "linux arm64 binary sha256sum is not provided"
       exit 1
 fi
 
@@ -29,6 +35,7 @@ echo $tag
 echo $darwin_sha_amd64
 echo $darwin_sha_arm64
 echo $linux_sha_amd64
+echo $linux_sha_arm64
 
 cat > gardenctl-v2.rb << EOF
 class GardenctlV2 < Formula
@@ -47,9 +54,14 @@ class GardenctlV2 < Formula
       sha256 "$darwin_sha_amd64"
     end
   elsif OS.linux?
-    url "https://github.com/gardener/gardenctl-v2/releases/download/$tag/gardenctl_v2_linux_amd64"
-    sha256 "$linux_sha_amd64"
-    depends_on :arch => :x86_64
+    if Hardware::CPU.arm?
+      url "https://github.com/gardener/gardenctl-v2/releases/download/$tag/gardenctl_v2_linux_arm64"
+      sha256 "$linux_sha_arm64"
+    else
+      url "https://github.com/gardener/gardenctl-v2/releases/download/$tag/gardenctl_v2_linux_amd64"
+      sha256 "$linux_sha_amd64"
+      depends_on :arch => :x86_64
+    end
   end
 
   def install

--- a/.github/workflows/update-gardenlogin.sh
+++ b/.github/workflows/update-gardenlogin.sh
@@ -4,6 +4,7 @@ tag=${1}
 darwin_sha_amd64=${2}
 darwin_sha_arm64=${3}
 linux_sha_amd64=${4}
+linux_sha_arm64=${5}
 if [ -z "${1}" ]
 then
       echo "release tag is not provided"
@@ -21,7 +22,12 @@ then
 fi
 if [ -z "${4}" ]
 then
-      echo "linux binary sha256sum is not provided"
+      echo "linux amd64 binary sha256sum is not provided"
+      exit 1
+fi
+if [ -z "${5}" ]
+then
+      echo "linux arm64 binary sha256sum is not provided"
       exit 1
 fi
 
@@ -29,6 +35,7 @@ echo $tag
 echo $darwin_sha_amd64
 echo $darwin_sha_arm64
 echo $linux_sha_amd64
+echo $linux_sha_arm64
 
 cat > gardenlogin.rb << EOF
 class Gardenlogin < Formula
@@ -45,9 +52,14 @@ class Gardenlogin < Formula
       sha256 "$darwin_sha_amd64"
     end
   elsif OS.linux?
-    url "https://github.com/gardener/gardenlogin/releases/download/$tag/gardenlogin_linux_amd64"
-    sha256 "$linux_sha_amd64"
-    depends_on :arch => :x86_64
+    if Hardware::CPU.arm?
+      url "https://github.com/gardener/gardenlogin/releases/download/$tag/gardenlogin_linux_arm64"
+      sha256 "$linux_sha_arm64"
+    else
+      url "https://github.com/gardener/gardenlogin/releases/download/$tag/gardenlogin_linux_amd64"
+      sha256 "$linux_sha_amd64"
+      depends_on :arch => :x86_64
+    end
   end
 
   def install

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -10,10 +10,11 @@ jobs:
           echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
           echo "Darwin amd64 gardenctl-v2 binary hash '${{ github.event.client_payload.darwin_sha_amd64 }}'"
           echo "Darwin arm64 gardenctl-v2 binary hash '${{ github.event.client_payload.darwin_sha_arm64 }}'"
-          echo "Linux gardenctl-v2 binary hash '${{ github.event.client_payload.linux_sha_amd64 }}'"
+          echo "Linux amd64 gardenctl-v2 binary hash '${{ github.event.client_payload.linux_sha_amd64 }}'"
+          echo "Linux arm64 gardenctl-v2 binary hash '${{ github.event.client_payload.linux_sha_arm64 }}'"
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - name: Run update script
-        run:  ./.github/workflows/update-gardenctl-v2.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.darwin_sha_amd64 }} ${{ github.event.client_payload.darwin_sha_arm64 }} ${{ github.event.client_payload.linux_sha_amd64 }}
+        run:  ./.github/workflows/update-gardenctl-v2.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.darwin_sha_amd64 }} ${{ github.event.client_payload.darwin_sha_arm64 }} ${{ github.event.client_payload.linux_sha_amd64 }} ${{ github.event.client_payload.linux_sha_arm64 }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # pin@v4.2.3
         with:
@@ -31,10 +32,11 @@ jobs:
           echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
           echo "Darwin amd64 gardenlogin binary hash '${{ github.event.client_payload.darwin_sha_amd64 }}'"
           echo "Darwin arm64 gardenlogin binary hash '${{ github.event.client_payload.darwin_sha_arm64 }}'"
-          echo "Linux gardenlogin binary hash '${{ github.event.client_payload.linux_sha_amd64 }}'"
+          echo "Linux amd64 gardenlogin binary hash '${{ github.event.client_payload.linux_sha_amd64 }}'"
+          echo "Linux arm64 gardenlogin binary hash '${{ github.event.client_payload.linux_sha_arm64 }}'"
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - name: Run update script
-        run:  ./.github/workflows/update-gardenlogin.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.darwin_sha_amd64 }} ${{ github.event.client_payload.darwin_sha_arm64 }} ${{ github.event.client_payload.linux_sha_amd64 }}
+        run:  ./.github/workflows/update-gardenlogin.sh ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.darwin_sha_amd64 }} ${{ github.event.client_payload.darwin_sha_arm64 }} ${{ github.event.client_payload.linux_sha_amd64 }} ${{ github.event.client_payload.linux_sha_arm64 }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # pin@v4.2.3
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
Support linux/arm64 builds for gardenctl-v2 and gardenlogin

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
