### PR TITLE
Add `kubelogin` install hint for `gardenlogin`

### DIFF
--- a/.github/workflows/update-gardenctl-v2.sh
+++ b/.github/workflows/update-gardenctl-v2.sh
@@ -5,30 +5,30 @@ darwin_sha_amd64=${2}
 darwin_sha_arm64=${3}
 linux_sha_amd64=${4}
 linux_sha_arm64=${5}
-if [ -z "${1}" ]
-then
-      echo "release tag is not provided"
-      exit 1
+
+if [ -z "${tag}" ]; then
+  echo "release tag is not provided"
+  exit 1
 fi
-if [ -z "${2}" ]
-then
-      echo "darwin amd64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${darwin_sha_amd64}" ]; then
+  echo "darwin amd64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${3}" ]
-then
-      echo "darwin arm64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${darwin_sha_arm64}" ]; then
+  echo "darwin arm64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${4}" ]
-then
-      echo "linux amd64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${linux_sha_amd64}" ]; then
+  echo "linux amd64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${5}" ]
-then
-      echo "linux arm64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${linux_sha_arm64}" ]; then
+  echo "linux arm64 binary sha256sum is not provided"
+  exit 1
 fi
 
 echo $tag

--- a/.github/workflows/update-gardenctl-v2.sh
+++ b/.github/workflows/update-gardenctl-v2.sh
@@ -76,12 +76,16 @@ class GardenctlV2 < Formula
 
   def install
     bin.install stable.url.split("/")[-1] => "gardenctl"
+  end
 
-    print "\n[HINT]\n"
-    print "  Consider to add the gardenctl startup script to your shell profile.\n"
-    print "  It contains various tweaks, such as setting environment variables,\n"
-    print "  loading completions and adding some helpful aliases or functions.\n"
-    print "  Run \`gardenctl rc --help\` for more information.\n\n"
+  def caveats
+    <<~EOS
+      [HINT]
+      Consider adding the gardenctl startup script to your shell profile.
+      It contains various tweaks, such as setting environment variables,
+      loading completions, and adding some helpful aliases or functions.
+      Run \`gardenctl rc --help\` for more information.
+    EOS
   end
 
   test do

--- a/.github/workflows/update-gardenlogin.sh
+++ b/.github/workflows/update-gardenlogin.sh
@@ -5,30 +5,30 @@ darwin_sha_amd64=${2}
 darwin_sha_arm64=${3}
 linux_sha_amd64=${4}
 linux_sha_arm64=${5}
-if [ -z "${1}" ]
-then
-      echo "release tag is not provided"
-      exit 1
+
+if [ -z "${tag}" ]; then
+  echo "release tag is not provided"
+  exit 1
 fi
-if [ -z "${2}" ]
-then
-      echo "darwin amd64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${darwin_sha_amd64}" ]; then
+  echo "darwin amd64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${3}" ]
-then
-      echo "darwin arm64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${darwin_sha_arm64}" ]; then
+  echo "darwin arm64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${4}" ]
-then
-      echo "linux amd64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${linux_sha_amd64}" ]; then
+  echo "linux amd64 binary sha256sum is not provided"
+  exit 1
 fi
-if [ -z "${5}" ]
-then
-      echo "linux arm64 binary sha256sum is not provided"
-      exit 1
+
+if [ -z "${linux_sha_arm64}" ]; then
+  echo "linux arm64 binary sha256sum is not provided"
+  exit 1
 fi
 
 echo $tag

--- a/.github/workflows/update-gardenlogin.sh
+++ b/.github/workflows/update-gardenlogin.sh
@@ -77,6 +77,14 @@ class Gardenlogin < Formula
     bin.install_symlink bin/"gardenlogin" => "kubectl-gardenlogin"
   end
 
+  def caveats
+    <<~EOS
+      If you are using an OIDC kubeconfig, you may need to install 'kubelogin'.
+      You can install it manually by running:
+        brew install int128/kubelogin/kubelogin
+    EOS
+  end
+
   test do
     system "#{bin}/gardenlogin", "version"
     system "#{bin}/kubectl-gardenlogin", "version"

--- a/gardenctl-v2.rb
+++ b/gardenctl-v2.rb
@@ -30,12 +30,16 @@ class GardenctlV2 < Formula
 
   def install
     bin.install stable.url.split("/")[-1] => "gardenctl"
+  end
 
-    print "\n[HINT]\n"
-    print "  Consider to add the gardenctl startup script to your shell profile.\n"
-    print "  It contains various tweaks, such as setting environment variables,\n"
-    print "  loading completions and adding some helpful aliases or functions.\n"
-    print "  Run `gardenctl rc --help` for more information.\n\n"
+  def caveats
+    <<~EOS
+      [HINT]
+      Consider adding the gardenctl startup script to your shell profile.
+      It contains various tweaks, such as setting environment variables,
+      loading completions, and adding some helpful aliases or functions.
+      Run `gardenctl rc --help` for more information.
+    EOS
   end
 
   test do

--- a/gardenlogin.rb
+++ b/gardenlogin.rb
@@ -1,5 +1,9 @@
+# typed: true
+# frozen_string_literal: true
+
+# Gardenlogin is a formula for installing Gardenlogin
 class Gardenlogin < Formula
-  desc "Gardenlogin"
+  desc "Command-line tool for authenticating with Gardener clusters"
   homepage "https://gardener.cloud"
   version "v0.5.1"
 
@@ -18,7 +22,7 @@ class Gardenlogin < Formula
     else
       url "https://github.com/gardener/gardenlogin/releases/download/v0.5.1/gardenlogin_linux_amd64"
       sha256 "dd53c642d49d6285b199f34053943d84c13013d31d84542ad6d1c5309dc63eac"
-      depends_on :arch => :x86_64
+      depends_on arch: :x86_64
     end
   end
 

--- a/gardenlogin.rb
+++ b/gardenlogin.rb
@@ -27,6 +27,14 @@ class Gardenlogin < Formula
     bin.install_symlink bin/"gardenlogin" => "kubectl-gardenlogin"
   end
 
+  def caveats
+    <<~EOS
+      If you are using an OIDC kubeconfig, you may need to install 'kubelogin'.
+      You can install it manually by running:
+        brew install int128/kubelogin/kubelogin
+    EOS
+  end
+
   test do
     system "#{bin}/gardenlogin", "version"
     system "#{bin}/kubectl-gardenlogin", "version"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `kubelogin` install hint for `gardenlogin`

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardenlogin/issues/142

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
