### PR TITLE
Brew: Automatically install shell completions

### DIFF
--- a/gardenctl-v2.rb
+++ b/gardenctl-v2.rb
@@ -30,6 +30,8 @@ class GardenctlV2 < Formula
 
   def install
     bin.install stable.url.split("/")[-1] => "gardenctl"
+
+    generate_completions_from_executable(bin/"gardenctl", "completion")
   end
 
   def caveats


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it so that the formula also installs the shell completions for `gardenctl`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
