### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,4 +1,6 @@
 name: Remote Dispatch Action
+permissions:
+  contents: write
 on: [repository_dispatch]
 jobs:
   update-gardenctl-v2:


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/homebrew-tap/security/code-scanning/1](https://github.com/gardener/homebrew-tap/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `contents: write` for creating pull requests and updating files.

The `permissions` block will be added at the top of the file, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
