### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/homebrew-tap/security/code-scanning/2](https://github.com/gardener/homebrew-tap/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow appears to only perform a compliance check and does not require write access, we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has only the necessary access to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
