### PR TITLE
update diki to v0.16.0

### DIFF
--- a/diki.rb
+++ b/diki.rb
@@ -5,23 +5,23 @@
 class Diki < Formula
   desc "Command-line tool for compliance checks"
   homepage "https://gardener.cloud"
-  version "0.15.1"
+  version "0.16.0"
 
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://github.com/gardener/diki/releases/download/v0.15.1/diki-darwin-arm64"
-      sha256 "a514901b9a521e7b72365418b418895a082077b8e06723c3f7bcc0f6501858d5"
+      url "https://github.com/gardener/diki/releases/download/v0.16.0/diki-darwin-arm64"
+      sha256 "56b22986df115da9a3cf578cb84115c50452d1f0c01ca974f0a39ccb30ce8170"
     else
-      url "https://github.com/gardener/diki/releases/download/v0.15.1/diki-darwin-amd64"
-      sha256 "583d03c9ec0890efe05a77c8c5727a3e888142704d6e86e91995cc2ad012d6a0"
+      url "https://github.com/gardener/diki/releases/download/v0.16.0/diki-darwin-amd64"
+      sha256 "1c52bde461c211fc9ba631ead5da3fba013713f175f6540f6418e7b66491108d"
     end
   elsif OS.linux?
     if Hardware::CPU.arm?
-      url "https://github.com/gardener/diki/releases/download/v0.15.1/diki-linux-arm64"
-      sha256 "49ce96ec6709293fa77e436faa61600e4e7597880ac6b6b261e7a0cb3226f183"
+      url "https://github.com/gardener/diki/releases/download/v0.16.0/diki-linux-arm64"
+      sha256 "bd64e0dd0ab38145c94848d213e49529651e02862c804b5509649dced5098cd4"
     else
-      url "https://github.com/gardener/diki/releases/download/v0.15.1/diki-linux-amd64"
-      sha256 "f414c1b2dda894d125781d35db6983cf8b5116eb5e33fb70b8a7b866a496e55b"
+      url "https://github.com/gardener/diki/releases/download/v0.16.0/diki-linux-amd64"
+      sha256 "058ecdf29aa87673f6df8efb4772de3b999b52a5f34e979574c331d4711e6dca"
       depends_on arch: :x86_64
     end
   end


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an error in the last update diki job. This PR manually updates diki to the newest version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
