### PR TITLE
ci: harden GitHub Actions security with zizmor

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -69,8 +69,10 @@ jobs:
 
       # ─────────────── show what we received / entered ───────────────
       - name: Event summary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo "Triggered by : ${{ github.event_name }}"
+          echo "Triggered by : $EVENT_NAME"
           echo "Component    : $COMPONENT"
           echo "Version tag  : $TAG"
           echo "darwin-amd64 : $DARWIN_SHA_AMD64"
@@ -109,6 +111,7 @@ jobs:
         env:
           GIT_PUSH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
           AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
@@ -131,6 +134,6 @@ jobs:
           git_with_auth push -u origin "$branch"
           gh pr create \
             --head "$branch" \
-            --base "${{ github.event.repository.default_branch }}" \
-            --title "update $COMPONENT to ${{ env.TAG }}" \
-            --body  "Updates Homebrew Formula for **$COMPONENT** (${{ env.TAG }})."
+            --base "$DEFAULT_BRANCH" \
+            --title "update $COMPONENT to $TAG" \
+            --body  "Updates Homebrew Formula for **$COMPONENT** ($TAG)."

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -80,6 +80,8 @@ jobs:
 
       # ──────────────────── repo checkout (pinned) ───────────────────
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          persist-credentials: false
 
       # ─────────────────── generate/update formula ───────────────────
       - name: Run component-specific update script
@@ -105,13 +107,28 @@ jobs:
             pull-requests: write
       - name: Create pull request
         env:
+          GIT_PUSH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         run: |
+          BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
+          AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
+
+          echo "::add-mask::$GIT_PUSH_TOKEN"
+          echo "::add-mask::$BASIC_AUTH"
+          echo "::add-mask::$AUTH_HEADER"
+
+          git_with_auth() {
+            GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
+            git "$@"
+          }
+
           branch="update_${COMPONENT}_${TAG}"
           git switch -c "$branch"
           git add "$COMPONENT.rb"
           git commit -m "update $COMPONENT to $TAG"
-          git push -u origin "$branch"
+          git_with_auth push -u origin "$branch"
           gh pr create \
             --head "$branch" \
             --base "${{ github.event.repository.default_branch }}" \

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -97,10 +97,10 @@ jobs:
 
       # ───────────────────────── git identity ────────────────────────
       - name: Setup Git Identity
-        uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
+        uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
       # ───────────────────── create pull request ─────────────────────
-      - uses: gardener/cc-utils/.github/actions/github-auth@v1
+      - uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         id: token
         with:
           token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -56,8 +56,8 @@ jobs:
       LINUX_SHA_ARM64: ${{ inputs.linux_sha_arm64 || github.event.client_payload.linux_sha_arm64 }}
 
     steps:
-      # ──────────────── ensure valid component name ─────────────────
-      - name: Validate component
+      # ──────────────── validate inputs ──────────────────────────────
+      - name: Validate inputs
         run: |
           case "$COMPONENT" in
             gardenlogin|gardenctl-v2|diki) ;;
@@ -66,6 +66,18 @@ jobs:
               exit 1
               ;;
           esac
+
+          if ! echo "$TAG" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "Error: Invalid tag '$TAG'"
+            exit 1
+          fi
+
+          for sha_val in "$DARWIN_SHA_AMD64" "$DARWIN_SHA_ARM64" "$LINUX_SHA_AMD64" "$LINUX_SHA_ARM64"; do
+            if ! echo "$sha_val" | grep -qE '^[0-9a-f]{64}$'; then
+              echo "Error: Invalid SHA256: '$sha_val'"
+              exit 1
+            fi
+          done
 
       # ─────────────── show what we received / entered ───────────────
       - name: Event summary

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -120,7 +120,7 @@ jobs:
             "$LINUX_SHA_AMD64"  "$LINUX_SHA_ARM64"
 
       - name: Upload updated formula
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: formula
           path: ${{ needs.resolve-inputs.outputs.component }}.rb

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -1,15 +1,13 @@
 name: Update Homebrew Formula
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 # ──────────────────────────────── TRIGGERS ────────────────────────────────
 on:
   # automatic calls from other repos
   repository_dispatch:
 
-  # manual “Run workflow” button
+  # manual "Run workflow" button
   workflow_dispatch:
     inputs:
       component:
@@ -43,21 +41,27 @@ on:
 
 # ───────────────────────────────── JOBS ───────────────────────────────────
 jobs:
-  update-formula:
+  # ─────────────────── 1. Validate & resolve inputs ────────────────────────
+  resolve-inputs:
     runs-on: ubuntu-latest
-
-    # -------- shared environment values (event-specific fall-backs) ---------
-    env:
-      TAG: ${{ inputs.tag || github.event.client_payload.tag }}
-      COMPONENT: ${{ inputs.component || github.event.client_payload.component }}
-      DARWIN_SHA_AMD64: ${{ inputs.darwin_sha_amd64 || github.event.client_payload.darwin_sha_amd64 }}
-      DARWIN_SHA_ARM64: ${{ inputs.darwin_sha_arm64 || github.event.client_payload.darwin_sha_arm64 }}
-      LINUX_SHA_AMD64: ${{ inputs.linux_sha_amd64 || github.event.client_payload.linux_sha_amd64 }}
-      LINUX_SHA_ARM64: ${{ inputs.linux_sha_arm64 || github.event.client_payload.linux_sha_arm64 }}
-
+    permissions: {}
+    outputs:
+      component: ${{ steps.validate.outputs.component }}
+      tag: ${{ steps.validate.outputs.tag }}
+      darwin_sha_amd64: ${{ steps.validate.outputs.darwin_sha_amd64 }}
+      darwin_sha_arm64: ${{ steps.validate.outputs.darwin_sha_arm64 }}
+      linux_sha_amd64: ${{ steps.validate.outputs.linux_sha_amd64 }}
+      linux_sha_arm64: ${{ steps.validate.outputs.linux_sha_arm64 }}
     steps:
-      # ──────────────── validate inputs ──────────────────────────────
       - name: Validate inputs
+        id: validate
+        env:
+          TAG: ${{ inputs.tag || github.event.client_payload.tag }}
+          COMPONENT: ${{ inputs.component || github.event.client_payload.component }}
+          DARWIN_SHA_AMD64: ${{ inputs.darwin_sha_amd64 || github.event.client_payload.darwin_sha_amd64 }}
+          DARWIN_SHA_ARM64: ${{ inputs.darwin_sha_arm64 || github.event.client_payload.darwin_sha_arm64 }}
+          LINUX_SHA_AMD64: ${{ inputs.linux_sha_amd64 || github.event.client_payload.linux_sha_amd64 }}
+          LINUX_SHA_ARM64: ${{ inputs.linux_sha_arm64 || github.event.client_payload.linux_sha_arm64 }}
         run: |
           case "$COMPONENT" in
             gardenlogin|gardenctl-v2|diki) ;;
@@ -79,25 +83,33 @@ jobs:
             fi
           done
 
-      # ─────────────── show what we received / entered ───────────────
-      - name: Event summary
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          echo "Triggered by : $EVENT_NAME"
-          echo "Component    : $COMPONENT"
-          echo "Version tag  : $TAG"
-          echo "darwin-amd64 : $DARWIN_SHA_AMD64"
-          echo "darwin-arm64 : $DARWIN_SHA_ARM64"
-          echo "linux-amd64  : $LINUX_SHA_AMD64"
-          echo "linux-arm64  : $LINUX_SHA_ARM64"
+          {
+            echo "component=$COMPONENT"
+            echo "tag=$TAG"
+            echo "darwin_sha_amd64=$DARWIN_SHA_AMD64"
+            echo "darwin_sha_arm64=$DARWIN_SHA_ARM64"
+            echo "linux_sha_amd64=$LINUX_SHA_AMD64"
+            echo "linux_sha_arm64=$LINUX_SHA_ARM64"
+          } >> "$GITHUB_OUTPUT"
 
-      # ──────────────────── repo checkout (pinned) ───────────────────
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+  # ─────────────────── 2. Update formula file ──────────────────────────────
+  update-formula:
+    needs: resolve-inputs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TAG: ${{ needs.resolve-inputs.outputs.tag }}
+      COMPONENT: ${{ needs.resolve-inputs.outputs.component }}
+      DARWIN_SHA_AMD64: ${{ needs.resolve-inputs.outputs.darwin_sha_amd64 }}
+      DARWIN_SHA_ARM64: ${{ needs.resolve-inputs.outputs.darwin_sha_arm64 }}
+      LINUX_SHA_AMD64: ${{ needs.resolve-inputs.outputs.linux_sha_amd64 }}
+      LINUX_SHA_ARM64: ${{ needs.resolve-inputs.outputs.linux_sha_arm64 }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      # ─────────────────── generate/update formula ───────────────────
       - name: Run component-specific update script
         run: |
           script=".github/workflows/update-$COMPONENT.sh"
@@ -107,11 +119,37 @@ jobs:
             "$DARWIN_SHA_AMD64" "$DARWIN_SHA_ARM64" \
             "$LINUX_SHA_AMD64"  "$LINUX_SHA_ARM64"
 
-      # ───────────────────────── git identity ────────────────────────
+      - name: Upload updated formula
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: formula
+          path: ${{ needs.resolve-inputs.outputs.component }}.rb
+          if-no-files-found: error
+          retention-days: 1
+
+  # ─────────────────── 3. Create pull request ──────────────────────────────
+  create-pr:
+    needs: [resolve-inputs, update-formula]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      TAG: ${{ needs.resolve-inputs.outputs.tag }}
+      COMPONENT: ${{ needs.resolve-inputs.outputs.component }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download updated formula
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: formula
+
       - name: Setup Git Identity
         uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
-      # ───────────────────── create pull request ─────────────────────
       - uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         id: token
         with:
@@ -119,6 +157,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permissions: |
             pull-requests: write
+
       - name: Create pull request
         env:
           GIT_PUSH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,32 @@
+name: Zizmor Workflow Lint
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '.github/**'
+  pull_request:
+    paths:
+    - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.24.1
+          min-severity: low
+          min-confidence: low
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Hardens GitHub Actions CI security across all workflows by addressing findings from zizmor static analysis. Changes include:

- Disable `persist-credentials` on checkout steps to avoid credential
  leakage in third-party action contexts
- Avoid direct use of expression contexts in `run:` scripts
- Suppress known-safe zizmor findings for same-org actions
- Add zizmor workflow lint job to catch future regressions
- Add dependabot cooldown to mitigate supply-chain risk
- Validate tag and SHA inputs in remote-dispatch to prevent injection
- Split remote-dispatch into least-privilege jobs with minimal token
  scopes

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```