### PR TITLE
ci: use ci- prefix for formula-update branches

### DIFF
--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -178,7 +178,7 @@ jobs:
             git "$@"
           }
 
-          branch="update_${COMPONENT}_${TAG}"
+          branch="ci-update-${COMPONENT}-${TAG}"
           git switch -c "$branch"
           git add "$COMPONENT.rb"
           git commit -m "update $COMPONENT to $TAG"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto


"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

The repository branch ruleset restricts which branch names can be created. The `Update Homebrew Formula` workflow created branches as `update_<component>_<tag>`, which is not on the allow-list, so the push step
failed (`GH013: Cannot create ref due to creations being restricted`).

This change renames the workflow branch pattern to `ci-update-<component>-<tag>`, which matches the allowed `ci-*` prefix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Failed run for reference:
https://github.com/gardener/homebrew-tap/actions/runs/26091266998/job/76717328825

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer

```